### PR TITLE
Fix execute.exp on wrynrose, update to latest trunk

### DIFF
--- a/execute.exp
+++ b/execute.exp
@@ -6,7 +6,7 @@ catch {set MACHINE $env(MACHINE)}
 
 set root_dir [file dirname [file normalize $::argv0]]
 
-spawn bash -c "cd $root_dir && source sources/poky/oe-init-build-env builds/build-${MACHINE} && runqemu ${MACHINE} nographic"
+spawn bash -c "cd $root_dir && source sources/openembedded-core/oe-init-build-env builds/build-${MACHINE} && runqemu ${MACHINE} snapshot nographic"
 
 set timeout 180
 

--- a/ubuntu22.04.dockerfile
+++ b/ubuntu22.04.dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y && \
     apt install -y gawk wget git-core diffstat unzip texinfo \
-    gcc-multilib build-essential chrpath socat file cpio python3 \
+    build-essential chrpath socat file cpio python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
     libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd \
     liblz4-tool libssl-dev bc lzop libgnutls28-dev efitools git-lfs \


### PR DESCRIPTION
Apparently with Yocto 6.0 qemu must be run in 'snapshot' mode for it to work, due to how the images are created or something...