### PR TITLE
Place Yocto build directory in volume on macOS by default, provide new BUILD_IN_VOLUME option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ sstate-cache/
 cache/
 deploy/
 downloads/
+output/
 
 # Ignore BitBake temporary files
 bitbake.lock

--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,7 @@ META_RASPBERRYPI_DIR=${META_RASPBERRYPI_DIR:=$SRC_ROOT/meta-raspberrypi}
 
 MACHINE="${MACHINE:=qemuarm}"
 BUILD_DIR=${BUILD_DIR:=$BUILD_ROOT/build-$MACHINE}
-DOWNLOADS_DIR=${DOWNLOADS_DIR:=$BUILD_ROOT/downloads}
-SSTATE_DIR=${SSTATE_DIR:=$BUILD_ROOT/sstate-cache}
+OUTPUT_DIR=${OUTPUT_DIR:=$(pwd)/output/build-$MACHINE}
 
 # For SWIFT_CXX_RUNTIME, we have 2 choices:
 # - "gnu" = libstdc++
@@ -56,3 +55,7 @@ COMMAND=${COMMAND:="bitbake core-image-minimal"}
 # run build command
 echo =============== BUILD COMMAND: $COMMAND
 $COMMAND
+
+echo "============== Copying build artifacts to output directory $OUTPUT_DIR"
+mkdir -p $OUTPUT_DIR 2> /dev/null || true
+cp -a $BUILD_DIR/tmp/deploy/* $OUTPUT_DIR 2> /dev/null || true

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,8 @@ set -e
 
 # Configuration
 BUILD_ROOT=${BUILD_ROOT:=$(pwd)/builds}
+DOWNLOADS_DIR=${DOWNLOADS_DIR:=$(pwd)/downloads}
+SSTATE_DIR=${SSTATE_DIR:=$(pwd)/sstate-cache}
 SRC_ROOT="${SRC_ROOT:=$(pwd)/sources}"
 OE_DIR="${OE_DIR:=$SRC_ROOT/openembedded-core}"
 META_SWIFT_DIR="${META_SWIFT_DIR:=$SRC_ROOT/meta-swift}"

--- a/env.sh
+++ b/env.sh
@@ -29,7 +29,3 @@ else
   echo "Error: Unsupported container runtime '${CONTAINER_ENGINE}'."
   exit 1
 fi
-
-# Yocto
-
-YOCTO_DIR="$PWD"

--- a/execute.exp
+++ b/execute.exp
@@ -6,7 +6,7 @@ catch {set MACHINE $env(MACHINE)}
 
 set root_dir [file dirname [file normalize $::argv0]]
 
-spawn bash -c "cd $root_dir && source sources/openembedded-core/oe-init-build-env builds/build-${MACHINE} && runqemu ${MACHINE} snapshot nographic"
+spawn bash -c "cd $root_dir && ./run.sh"
 
 set timeout 180
 
@@ -43,4 +43,3 @@ expect {
         exit 1
     }
 }
-

--- a/run-container.sh
+++ b/run-container.sh
@@ -23,8 +23,8 @@ fi
 # run the docker image
 $CONTAINER_ENGINE run -it --rm \
   ${CONTAINER_RUN_PARAMS} \
-  --volume ${HOME}:${HOME} \
-  --device /dev/net/tun \
+  --volume "${HOME}":"${HOME}" \
+  --volume meta-swift-examples:"${PWD}/builds" \
   --cap-add=NET_ADMIN \
     "${IMAGE_TAG}" \
     "$@"

--- a/run-container.sh
+++ b/run-container.sh
@@ -30,6 +30,7 @@ fi
 BUILDS_DIR="${PWD}/builds"
 $CONTAINER_ENGINE run -it --rm \
   ${CONTAINER_RUN_PARAMS} \
+  --device /dev/net/tun \
   --volume "${HOME}":"${HOME}" \
   --volume meta-swift-examples:"${BUILDS_DIR}" \
   --cap-add=NET_ADMIN \

--- a/run-container.sh
+++ b/run-container.sh
@@ -20,11 +20,18 @@ if [[ $PWD != $HOME* && $(whoami) != "root" ]]; then
     exit 1
 fi
 
+if [ "$#" -gt 0 ]; then
+  COMMAND="$*"
+else
+  COMMAND="exec bash"
+fi
+
 # run the docker image
+BUILDS_DIR="${PWD}/builds"
 $CONTAINER_ENGINE run -it --rm \
   ${CONTAINER_RUN_PARAMS} \
   --volume "${HOME}":"${HOME}" \
-  --volume meta-swift-examples:"${PWD}/builds" \
+  --volume meta-swift-examples:"${BUILDS_DIR}" \
   --cap-add=NET_ADMIN \
-    "${IMAGE_TAG}" \
-    "$@"
+  "${IMAGE_TAG}" \
+  /bin/bash -c "sudo chown $(id -u):$(id -g) ${BUILDS_DIR} && $COMMAND"

--- a/run-container.sh
+++ b/run-container.sh
@@ -26,13 +26,28 @@ else
   COMMAND="exec bash"
 fi
 
-# run the docker image
+# Option to put the Yocto builds/ directory in a volume
+# Defaults to true on macOS (needed due to hard link limitation), and false otherwise
+if [ -z "$BUILD_IN_VOLUME" ]; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Detected macOS host, automatically setting BUILD_IN_VOLUME to true"
+    BUILD_IN_VOLUME=true
+  else
+    BUILD_IN_VOLUME=false
+  fi
+fi
+
 BUILDS_DIR="${PWD}/builds"
+if [ "$BUILD_IN_VOLUME" = "true" ] || [ "$BUILD_IN_VOLUME" = "1" ]; then
+  echo "Using volume for Yocto builds directory: ${BUILDS_DIR}"
+  CONTAINER_RUN_PARAMS="${CONTAINER_RUN_PARAMS} --volume meta-swift-examples:${BUILDS_DIR}"
+fi
+
+# run the docker image
 $CONTAINER_ENGINE run -it --rm \
-  ${CONTAINER_RUN_PARAMS} \
   --device /dev/net/tun \
-  --volume "${HOME}":"${HOME}" \
-  --volume meta-swift-examples:"${BUILDS_DIR}" \
   --cap-add=NET_ADMIN \
+  --volume "${HOME}":"${HOME}" \
+  ${CONTAINER_RUN_PARAMS} \
   "${IMAGE_TAG}" \
   /bin/bash -c "sudo chown $(id -u):$(id -g) ${BUILDS_DIR} && $COMMAND"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Configuration
+BUILD_ROOT=${BUILD_ROOT:=$(pwd)/builds}
+SRC_ROOT="${SRC_ROOT:=$(pwd)/sources}"
+OE_DIR="${OE_DIR:=$SRC_ROOT/openembedded-core}"
+MACHINE="${MACHINE:=qemuarm}"
+BUILD_DIR=${BUILD_DIR:=$BUILD_ROOT/build-$MACHINE}
+
+source "$OE_DIR/oe-init-build-env" "$BUILD_DIR"
+runqemu $MACHINE snapshot nographic


### PR DESCRIPTION
This makes it possible to compile Yocto on macOS in Docker Desktop or Podman Desktop for example.

- With this change, you'll `./build.sh` inside of `./run-container.sh` as before. But when the build completes, the deploy directory gets copied to output/build-$MACHINE so it is accessible outside of the container.
- I moved the downloads/ and sstate-cache/ directories back to the root since we want to potentially be able to share those between the container and host system.
- By default on macOS we will build Yocto in a volume. However, the new `BUILD_IN_VOLUME` parameter can be used to force enable building in the volume on Linux as well, if needed (could be useful for Docker Desktop / Podman Desktop on Linux which appears to have similar issues with volume mounts from the host).