### PR TITLE
Support Apple `container` image

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -12,6 +12,8 @@ if [ -z "$CONTAINER_ENGINE" ]; then
     CONTAINER_ENGINE="docker"
   elif podman ps &> /dev/null; then
     CONTAINER_ENGINE="podman"
+  elif container ls &> /dev/null; then
+    CONTAINER_ENGINE="container"
   else
     echo "Error: Unable to find a running 'docker' or 'podman' instance to use as the container engine."
     exit 1
@@ -22,9 +24,11 @@ fi
 
 if [ "$CONTAINER_ENGINE" = "docker" ]; then
   # Add extra params for docker if needed
-  CONTAINER_RUN_PARAMS=""
+  CONTAINER_RUN_PARAMS="--device /dev/net/tun"
 elif [ "$CONTAINER_ENGINE" = "podman" ]; then
-  CONTAINER_RUN_PARAMS="--userns=keep-id:uid=$(id -u),gid=$(id -g)"
+  CONTAINER_RUN_PARAMS="--device /dev/net/tun --userns=keep-id:uid=$(id -u),gid=$(id -g)"
+elif [ "$CONTAINER_ENGINE" = "container" ]; then
+  CONTAINER_RUN_PARAMS=""
 else
   echo "Error: Unsupported container runtime '${CONTAINER_ENGINE}'."
   exit 1

--- a/run-container.sh
+++ b/run-container.sh
@@ -45,7 +45,6 @@ fi
 
 # run the docker image
 $CONTAINER_ENGINE run -it --rm \
-  --device /dev/net/tun \
   --cap-add=NET_ADMIN \
   --volume "${HOME}":"${HOME}" \
   ${CONTAINER_RUN_PARAMS} \


### PR DESCRIPTION
It must be configured to limit the max number of CPUs and RAM to use, otherwise the Yocto build will likely run into thrashing issues and fail as I saw previously.

```shell
$ mkdir -p ~/.config/container/ && vim ~/.config/container/config.toml
[container]
cpus = 6
memory = "12g"
$ container system stop && container system start
```

Then, with the `container system` running, the meta-swift-examples scripts will see `container` and use it as the engine for the container.
