### PR TITLE
Disable label security when using Podman

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -23,10 +23,13 @@ if [ -z "$CONTAINER_ENGINE" ]; then
 fi
 
 if [ "$CONTAINER_ENGINE" = "docker" ]; then
-  # Add extra params for docker if needed
   CONTAINER_RUN_PARAMS="--device /dev/net/tun"
 elif [ "$CONTAINER_ENGINE" = "podman" ]; then
-  CONTAINER_RUN_PARAMS="--device /dev/net/tun --userns=keep-id:uid=$(id -u),gid=$(id -g)"
+  CONTAINER_RUN_PARAMS="\
+    --device /dev/net/tun \
+    --userns=keep-id:uid=$(id -u),gid=$(id -g) \
+    --security-opt label:disable \
+  "
 elif [ "$CONTAINER_ENGINE" = "container" ]; then
   CONTAINER_RUN_PARAMS=""
 else


### PR DESCRIPTION
On Bazzite / Fedora Atomic, everything that involves development or building things is typically done inside of a Toolbox (which is Podman under the hood) or in a Podman container. SElinux is also enabled, but doesn't play well with the meta-swift-examples because they share the entire $HOME directory, and $HOME cannot be re-labeled. 
 
- Sharing the whole home folder is not secure anyways, but for the purposes of meta-swift-examples we want to do it to match the functionality of docker/container.
 - This allows /home/xtremek to be shared without relabeling or having to disable SElinux on RHEL hosts.